### PR TITLE
Change handling of non string values

### DIFF
--- a/lib/normalize_numbers/base.rb
+++ b/lib/normalize_numbers/base.rb
@@ -18,7 +18,7 @@ module NormalizeNumbers
             method = "#{attr}=".to_sym
             define_method(method) do |arg|
               return super arg.tr(',', '.') if arg.is_a? String
-              super
+              super arg
             end
           end
         end


### PR DESCRIPTION
When non string value was assigned to normalized attribute it was not passed to its super.
